### PR TITLE
Add an option to focus tab, instead of opening a new window

### DIFF
--- a/lib/TabManager.js
+++ b/lib/TabManager.js
@@ -95,6 +95,15 @@ var TabManager = React.createFactory(React.createClass({
 	deleteTab:function(tabId) {
 		chrome.tabs.remove(tabId);
 	},
+	focusTab:function(){
+		var tabs = Object.keys(this.state.selection).map(id => this.state.tabsbyid[id]);
+		var first = tabs.shift();
+		if(first){
+			chrome.tabs.update(first.id, {active: true}, function(tab) {
+				chrome.windows.update(tab.windowId, {focused: true});
+			});
+		}
+	},
 	addWindow:function(){
 		var tabs = Object.keys(this.state.selection).map(id => this.state.tabsbyid[id]);
 		var first = tabs.shift();
@@ -167,7 +176,13 @@ var TabManager = React.createFactory(React.createClass({
 		this.forceUpdate();
 	},
 	checkEnter:function(e){
-		if(e.keyCode == 13) this.addWindow();
+		if(e.keyCode == 13) {
+			if(e.nativeEvent.shiftKey){
+				this.focusTab();
+			}else{
+				this.addWindow();
+			}
+		}
 	},
 	changelayout:function(){
 		if(this.state.layout == "blocks"){


### PR DESCRIPTION
by clicking shift+enter from the search input, the first tab in the filtered tabs list will be focused.